### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: build nodejs Application 
+permissions:
+  contents: read
 on: 
  workflow_dispatch:
  push:


### PR DESCRIPTION
Potential fix for [https://github.com/harshraisaxena/GithubActions-NodeJs-Demo/security/code-scanning/4](https://github.com/harshraisaxena/GithubActions-NodeJs-Demo/security/code-scanning/4)

To fix the issue, add an explicit `permissions` section to the workflow file, restricting the GITHUB_TOKEN permissions to only what is required. Since the shown jobs only check out code (which requires only `contents: read`) and set up Node.js, `contents: read` is sufficient. The best practice is to add the `permissions` block at the top, making it apply to all jobs (unless they override it later). Add the following immediately after the `name:` block and before the `on:` block in `.github/workflows/build.yml`:

```yaml
permissions:
  contents: read
```

No additional methods or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
