### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main1.yml
+++ b/.github/workflows/main1.yml
@@ -1,4 +1,6 @@
 name: build nodejs Application
+permissions:
+  contents: read
 on:
  workflow_dispatch:
  push:


### PR DESCRIPTION
Potential fix for [https://github.com/harshraisaxena/GithubActions-NodeJs-Demo/security/code-scanning/3](https://github.com/harshraisaxena/GithubActions-NodeJs-Demo/security/code-scanning/3)

To address this problem, the workflow YAML should be updated to include a `permissions` block to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since there is no evidence in the shown YAML that any steps require write access to repository content or pull-requests, setting `permissions: contents: read` at the workflow (root) level is the safest and most appropriate fix. This block should be placed immediately under the `name` field and before the `on` key, or alternatively, as the first field after `on:` (YAML field order is not strictly enforced by GitHub Actions).

The single best fix is to add these lines:
```yaml
permissions:
  contents: read
```
immediately after the `name: build nodejs Application` line on line 1.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
