### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: build nodejs Application
+permissions:
+  contents: read
 on:
  workflow_dispatch:
  push:


### PR DESCRIPTION
Potential fix for [https://github.com/harshraisaxena/GithubActions-NodeJs-Demo/security/code-scanning/2](https://github.com/harshraisaxena/GithubActions-NodeJs-Demo/security/code-scanning/2)

To correctly fix this issue, we need to add an explicit `permissions` block to the workflow to restrict the `GITHUB_TOKEN` permissions per best practice. The minimal safe starting point is `contents: read`, which allows jobs to read repository contents but not modify them. 

The best place to add this is at the workflow root (directly under the workflow `name:` and `on:` block) so it applies to all jobs unless a job-level override is required. None of the listed steps require write access to contents, issues, or pull requests (they only install dependencies, build, test, and use a dummy "deploy"), so `contents: read` is sufficient. 

**File/Region to change:**  
- `.github/workflows/main.yml`
- Insert a `permissions:` block near the top, after `name:` and before `on:` or directly after `on:` block.

**Requirements to implement:**  
- No imports or dependency changes are required—just a YAML edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
